### PR TITLE
Added API Enablement Requirement as Pre-requisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Scripts to create and manage a Docker Swarm cluster on Google Cloud Platform.
 - [Google Cloud SDK](http://cloud.google.com/sdk)
 
 ### Before you start
-Make sure you create a [Google Cloud Project](http://console.cloud.google.com/project)
+- Make sure you create a [Google Cloud Project](http://console.cloud.google.com/project)
+
+- You need to enable Google Cloud Deployment Manager V2 API using [this](https://console.developers.google.com/apis/api/deploymentmanager.googleapis.com) link.
 
 Login: 
 


### PR DESCRIPTION
While trying to build up Docker Swarm Cluster, I faced this issue:

ERROR: (gcloud.deployment-manager.deployments.create) ResponseError: code=403, message=Access Not Configured. Google Cloud Deployment Manager API has not been used in project 454903678544 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/deploymentmanager.googleapis.com/overview?project=xxxxxxxx then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.

Added a line under Pre-requisite for enabling API Manager.